### PR TITLE
Use skunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a full-stack Scala application (simple key-value management store), made
 2. [Smithy4s](https://disneystreaming.github.io/smithy4s/) and [Smithy](https://awslabs.github.io/smithy/2.0/index.html#) for the API and protocol 
    definition between backend and frontend (and in tests)
 3. [Scala.js](https://www.scala-js.org) and [Laminar](https://laminar.dev) for the [SPA](https://en.wikipedia.org/wiki/Single-page_application) frontend
-4. [PostgreSQL](https://www.postgresql.org) and [Doobie](https://tpolecat.github.io/doobie/) for database access 
+4. [PostgreSQL](https://www.postgresql.org) and [Skunk](https://github.com/typelevel/skunk) for database access 
 5. [Weaver-Test](https://disneystreaming.github.io/weaver-test/) for unit and integration testing
 6. [Playwright](https://playwright.dev/) tests for frontend testing, using the dedicated [Weaver integration](https://github.com/indoorvivants/weaver-playwright)
 
@@ -51,7 +51,7 @@ After that, just do `sbt app/reStart` and go to http://localhost:9000
 ## Features
 
 - Database 
-  - uses Doobie for database access and [Flyway](https://flywaydb.org) to apply migrations
+  - uses Skunk for database access and [Flyway](https://flywaydb.org) to apply migrations
 
 - Deployment
   - uses [sbt-native-packager](https://sbt-native-packager.readthedocs.io/en/latest/) 

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val Versions = new {
 
   val circe = "0.14.5"
 
-  val doobie = "1.0.0-RC2"
+  val skunk = "0.6.4"
 
   val macroTaskExecutor = "1.1.1"
 
@@ -106,9 +106,7 @@ lazy val backend = projectMatrix
       "com.outr"     %% "scribe"          % Versions.scribe,
       "com.outr"     %% "scribe-cats"     % Versions.scribe,
       "com.outr"     %% "scribe-slf4j"    % Versions.scribe,
-      "org.tpolecat" %% "doobie-core"     % Versions.doobie,
-      "org.tpolecat" %% "doobie-postgres" % Versions.doobie,
-      "org.tpolecat" %% "doobie-hikari"   % Versions.doobie
+      "org.tpolecat" %% "skunk-core"      % Versions.skunk, 
     ),
     Compile / doc / sources := Seq.empty
   )

--- a/modules/app/src/main/scala/bootstrap.scala
+++ b/modules/app/src/main/scala/bootstrap.scala
@@ -1,5 +1,6 @@
 package hellosmithy4s
 
+import natchez.Trace
 import cats.effect.*
 import cats.syntax.all.*
 import org.http4s.server.Server
@@ -8,7 +9,7 @@ import java.io.File
 def bootstrap(
     arguments: List[String],
     systemEnv: Map[String, String]
-): Resource[IO, Server] =
+)(using trace: Trace[IO]): Resource[IO, Server] =
   val logger = scribe.cats.io
   val cliConfig =
     CLIConfig(None, Option(new File(".env")), Deployment.Local, Cloud.Flyio)
@@ -45,7 +46,7 @@ def bootstrap(
 
     pgCredentials = cloudDb.getOrElse(PgCredentials.from(env))
 
-    db <- DoobieDatabase.hikari(pgCredentials)
+    db <- SkunkDatabase.make(pgCredentials)
 
     services = Services.build(
       logger,

--- a/modules/app/src/main/scala/run.scala
+++ b/modules/app/src/main/scala/run.scala
@@ -2,6 +2,7 @@ package hellosmithy4s
 
 import cats.effect.IOApp
 import cats.syntax.all.*
+import natchez.Trace.Implicits.noop
 
 object Run extends IOApp:
   def run(args: List[String]) =

--- a/modules/backend/src/main/scala/database.operations.scala
+++ b/modules/backend/src/main/scala/database.operations.scala
@@ -5,73 +5,72 @@ import cats.effect.IO
 import spec.*
 
 import cats.*, cats.data.*, cats.implicits.*
-import doobie.*, doobie.implicits.*
+import skunk.{Codec, Query}
+import skunk.implicits.*
+import skunk.codec.all.*
+
 import smithy4s.Newtype
+import skunk.data.Completion
+import skunk.Command
 
 sealed trait SqlOp[I, O]
 
-sealed abstract class SqlQuery[I, O](val input: I, val out: Query0[O])
+sealed abstract class SqlQuery[I, O](val input: I, val out: Query[I, O])
     extends SqlOp[I, O]
-sealed abstract class SqlUpdate[I](val input: I, val out: Update0)
+
+sealed abstract class SqlUpdate[I](val input: I, val out: Command[I])
     extends SqlOp[I, Int]
 
-private def ntGet[T: Get](nt: Newtype[T]): Get[nt.Type] =
-  Get[T].map(nt.apply)
-
-private def ntPut[T: Put](nt: Newtype[T]): Put[nt.Type] =
-  Put[T].contramap[nt.Type](_.value)
-
-given Get[Key]   = ntGet(Key)
-given Get[Value] = ntGet(Value)
-
-given Put[Key]   = ntPut(Key)
-given Put[Value] = ntPut(Value)
+def newtypeCodec[A](nt: Newtype[A], underlying: Codec[A]): Codec[nt.Type] =
+  underlying.imap(nt.apply)(_.value)
+val keyCodec   = newtypeCodec(Key, varchar(50))
+val valueCodec = newtypeCodec(Value, int4)
+val pairCodec  = (keyCodec *: valueCodec).to[Pair]
 
 object operations:
 
   case class Get(key: Key)
       extends SqlQuery(
         key,
-        sql"select value from examples where key = $key"
-          .query[Int]
-          .map(Value.apply)
+        sql"select value from examples where key = ${newtypeCodec(Key, varchar(50))}"
+          .query(valueCodec)
       )
 
   case object GetAll
       extends SqlQuery(
-        (),
+        skunk.Void,
         sql"select key, value from examples order by key"
-          .query[(Key, Value)]
-          .map(Pair.apply)
+          .query(pairCodec)
       )
 
-  case class Create(key: Key, value: Option[Value])
+  case class Create(key: Key, value: Value)
       extends SqlUpdate(
-        key,
-        sql"insert into examples (key, value) values ($key, ${value.map(_.value).getOrElse(0)})".update
+        (key, value),
+        sql"insert into examples (key, value) values ($keyCodec, $valueCodec)".command
       )
 
   case class Delete(key: Key)
       extends SqlUpdate(
         key,
-        sql"delete from examples where key = $key".update
+        sql"delete from examples where key = $keyCodec".command
       )
 
   case class Inc(key: Key)
       extends SqlUpdate(
         key,
-        sql"update examples set value = value + 1 where key = $key".update
+        sql"update examples set value = value + 1 where key = $keyCodec".command
       )
 
   case class Dec(key: Key)
       extends SqlUpdate(
         key,
-        sql"update examples set value = value - 1 where key = $key".update
+        sql"update examples set value = value - 1 where key = $keyCodec".command
       )
 
   case class Update(key: Key, value: Value)
       extends SqlUpdate(
-        key,
-        sql"update examples set value = ${value.value} where key = $key".update
+        (key, value),
+        sql"update examples set value = ${valueCodec} where key = $keyCodec".command
+          .contramap(_.swap)
       )
 end operations

--- a/modules/backend/src/main/scala/service.hello.scala
+++ b/modules/backend/src/main/scala/service.hello.scala
@@ -25,7 +25,7 @@ class HelloImplementation(logger: Scribe[IO], database: Database)
 
   override def create(key: Key, value: Option[Value]): IO[Unit] =
     database
-      .option(operations.Create(key, value))
+      .option(operations.Create(key, value.getOrElse(Value(0))))
       .attempt
       .flatMap {
         case Left(err) =>

--- a/modules/tests/src/test/scala/integration/tests.scala
+++ b/modules/tests/src/test/scala/integration/tests.scala
@@ -3,6 +3,7 @@ package tests
 package integration
 
 import cats.effect.kernel.Resource
+import natchez.Trace.Implicits.noop
 
 object HelloTests extends BaseSuite with HelloSuite:
   override def sharedResource: Resource[cats.effect.IO, Res] =

--- a/modules/tests/src/test/scala/playwright/FrontendTests.scala
+++ b/modules/tests/src/test/scala/playwright/FrontendTests.scala
@@ -4,6 +4,7 @@ package playwright
 
 import com.indoorvivants.weaver.playwright.*
 
+import natchez.Trace.Implicits.noop
 import cats.syntax.all.*
 import cats.effect.IO
 import org.http4s.Uri

--- a/modules/tests/src/test/scala/stub/InMemoryDatabase.scala
+++ b/modules/tests/src/test/scala/stub/InMemoryDatabase.scala
@@ -20,7 +20,7 @@ class InMemoryDatabase private (rf: Ref[IO, Map[Key, Value]]) extends Database:
         fs2.Stream
           .eval(rf.modify { mp =>
             if mp.contains(key) then mp -> IO.raiseError(KeyAlreadyExists())
-            else mp.updated(key, value.getOrElse(Value(0))) -> IO.pure(1)
+            else mp.updated(key, value) -> IO.pure(1)
           })
           .evalMap(identity)
       case Delete(key) =>


### PR DESCRIPTION
Closes https://github.com/indoorvivants/smithy4s-fullstack-template/issues/150 , reminder to change target branch if you don't want it in main,

Did this as an exercise but feel free to use if useful.
I would personally default to skunk 1.x-milestone, mostly because it's using otel4s and if this is a template for greenfield projects, it's better to guide people to use that. The reason is, even for a trivial project that already uses natchez the migration is [not trivial](https://github.com/dimitarg/taftotita/commit/e7584650fe5e5f4ce1bc15e3597175a5f2d8146d) so you want to avoid that if possible. 

However, I felt it's outside the scope.